### PR TITLE
issues: use correct url with limit and offset values

### DIFF
--- a/issues.go
+++ b/issues.go
@@ -241,7 +241,7 @@ func (r *Context) IssuesAllGet(request IssueAllGetRequest) (IssueResult, StatusC
 			&i,
 			url.URL{
 				Path:     "/issues.json",
-				RawQuery: request.url().Encode(),
+				RawQuery: up.Encode(),
 			},
 			http.StatusOK,
 		)


### PR DESCRIPTION
The `IssuesAllGet` function was using the URL from the original request, which did not have the `limit` and `offset` parameters set. As a result, the request only retrieved the first 25 issues, since the default values for `limit` and `offset` are 25 and 0, respectively.